### PR TITLE
Fix erroneous reading ref; cf, BCP 992.

### DIFF
--- a/episcopal_api/crates/lectionary/src/lectionaries/bcp1979_office.rs
+++ b/episcopal_api/crates/lectionary/src/lectionaries/bcp1979_office.rs
@@ -14890,7 +14890,7 @@ pub const BCP1979_DAILY_OFFICE_LECTIONARY: Lectionary = Lectionary {
             LiturgicalDayId::ProperAndDay(Proper::Proper27, Weekday::Sat),
             Year::DailyOffice(DailyOfficeYear::One),
             ReadingType::Gospel,
-            "Mark 16:21-28",
+            "Matt. 16:21-28",
         ),
         (
             LiturgicalDayId::ProperAndDay(Proper::Proper27, Weekday::Sat),


### PR DESCRIPTION
User found an error; fortunately and amusingly, even the longer Mark ends precisely before the verse specified.